### PR TITLE
Feature/#2 서버간 메시징 기능 구축

### DIFF
--- a/src/main/java/com/flab/matchingtaxi/config/RedisConfig.java
+++ b/src/main/java/com/flab/matchingtaxi/config/RedisConfig.java
@@ -1,0 +1,44 @@
+package com.flab.matchingtaxi.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean(name = "connectionFactory")
+    LettuceConnectionFactory connectionFactory(){
+
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    RedisMessageListenerContainer container(){
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory());
+        return container;
+    }
+
+    @Bean
+    @Qualifier("redisTemplate")
+    public RedisTemplate<String, Object> redisTemplate(){
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/flab/matchingtaxi/controller/RedisController.java
+++ b/src/main/java/com/flab/matchingtaxi/controller/RedisController.java
@@ -1,0 +1,38 @@
+package com.flab.matchingtaxi.controller;
+
+import com.flab.matchingtaxi.model.RemoteMessage;
+import com.flab.matchingtaxi.service.redis.RedisService;
+import com.flab.matchingtaxi.util.RemoteMessageMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@Slf4j
+public class RedisController {
+
+    @Autowired
+    private RedisService redisService;
+
+    @PostMapping("/publish")
+    private ResponseEntity publish(@RequestParam String topic, @RequestParam String content){
+        RemoteMessage message = RemoteMessageMapper.paramMapping("", topic, content);
+        redisService.publish(message);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    @PostMapping("/post/topic")
+    private ResponseEntity createTopic(@RequestParam String name){
+        ChannelTopic topic = redisService.createTopic(name);
+        return new ResponseEntity(topic, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/delete/topic")
+    private ResponseEntity deleteTopic(@RequestParam String name){
+        redisService.deleteTopic(name);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/flab/matchingtaxi/model/RemoteMessage.java
+++ b/src/main/java/com/flab/matchingtaxi/model/RemoteMessage.java
@@ -1,0 +1,14 @@
+package com.flab.matchingtaxi.model;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class RemoteMessage{
+    private String sender;
+    private String topic;
+    private String content;
+}

--- a/src/main/java/com/flab/matchingtaxi/repo/redis/RemoteMessageRepository.java
+++ b/src/main/java/com/flab/matchingtaxi/repo/redis/RemoteMessageRepository.java
@@ -1,0 +1,73 @@
+package com.flab.matchingtaxi.repo.redis;
+
+import com.flab.matchingtaxi.service.redis.RemoteMessageSubscriber;
+import com.flab.matchingtaxi.std.RedisStandard;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.Map;
+
+@Repository
+@Slf4j
+public class RemoteMessageRepository {
+
+    @Autowired
+    private RedisMessageListenerContainer redisMessageListenerContainer;
+    @Autowired
+    private RemoteMessageSubscriber remoteMessageSubscriber;
+
+    // redis
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+    private HashOperations<String, String, String> hashOperations;
+
+    // topic hash table
+    private Map<String, ChannelTopic> topics;
+
+    @PostConstruct
+    private void init(){
+        hashOperations = redisTemplate.opsForHash();
+        topics = new HashMap<>();
+    }
+
+    // 토픽 생성, 구독
+    public ChannelTopic createTopic(String name){
+        if(!hashOperations.hasKey(RedisStandard.HASHOPS_KEY_CHANNEL, name)){
+            hashOperations.put(RedisStandard.HASHOPS_KEY_CHANNEL, name, name);
+        }
+        String key = hashOperations.get(RedisStandard.HASHOPS_KEY_CHANNEL, name);
+        ChannelTopic topic;
+        if(topics.containsKey(key)){
+            topic = topics.get(key);
+        }
+        else {
+            topic = new ChannelTopic(key);
+            topics.put(key, topic);
+        }
+        redisMessageListenerContainer.addMessageListener(remoteMessageSubscriber, topic);
+        log.info("create topic successed : " + topic.toString());
+        return topic;
+    }
+
+    // 토픽 제거
+    public boolean deleteTopic(String name){
+        ChannelTopic topic = topics.get(name);
+        if(topic == null) return false;
+        topics.remove(name, topic);
+        redisMessageListenerContainer.removeMessageListener(remoteMessageSubscriber, topic);
+        return true;
+    }
+
+    // 토픽 조회
+    public ChannelTopic getTopic(String name){
+        String val = hashOperations.get(RedisStandard.HASHOPS_KEY_CHANNEL, name);
+        return topics.get(val);
+    }
+}

--- a/src/main/java/com/flab/matchingtaxi/service/redis/RedisService.java
+++ b/src/main/java/com/flab/matchingtaxi/service/redis/RedisService.java
@@ -1,0 +1,55 @@
+package com.flab.matchingtaxi.service.redis;
+
+import com.flab.matchingtaxi.model.RemoteMessage;
+import com.flab.matchingtaxi.repo.redis.RemoteMessageRepository;
+import com.flab.matchingtaxi.service.redis.RemoteMessagePublisher;
+import com.flab.matchingtaxi.std.RedisStandard;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class RedisService {
+
+    @Autowired
+    private RemoteMessageRepository remoteMessageRepository;
+
+    @Autowired
+    private RemoteMessagePublisher remoteMessagePublisher;
+
+    // 구독 생성
+    public ChannelTopic createTopic(String name){
+        return remoteMessageRepository.createTopic(name);
+    }
+
+    // 구독 제거
+    public boolean deleteTopic(String name) {
+        if (getTopic(name) != null) {
+            RemoteMessage message = RemoteMessage.builder()
+                    .topic(name)
+                    .content(RedisStandard.RM_COMMAND_DELETE)
+                    .build();
+            publish(message);
+        }
+        if (remoteMessageRepository.deleteTopic(name)) {
+            log.info("delete topic successed");
+            return true;
+        }
+        log.info("delete topic failed");
+        return false;
+    }
+
+    // 발행
+    public void publish(RemoteMessage message) {
+        ChannelTopic topic = getTopic(message.getTopic());
+        if(topic != null) {
+            remoteMessagePublisher.publish(topic, message);
+        }
+    }
+
+    public ChannelTopic getTopic(String name) {
+        return remoteMessageRepository.getTopic(name);
+    }
+}

--- a/src/main/java/com/flab/matchingtaxi/service/redis/RemoteMessagePublisher.java
+++ b/src/main/java/com/flab/matchingtaxi/service/redis/RemoteMessagePublisher.java
@@ -1,0 +1,21 @@
+package com.flab.matchingtaxi.service.redis;
+
+import com.flab.matchingtaxi.model.RemoteMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class RemoteMessagePublisher {
+
+    @Autowired
+    private RedisTemplate redisTemplate;
+
+    public void publish(ChannelTopic topic, RemoteMessage message){
+        redisTemplate.convertAndSend(topic.getTopic(), message);
+        log.info("publish message : " + message.toString());
+    }
+}

--- a/src/main/java/com/flab/matchingtaxi/service/redis/RemoteMessageSubscriber.java
+++ b/src/main/java/com/flab/matchingtaxi/service/redis/RemoteMessageSubscriber.java
@@ -1,0 +1,46 @@
+package com.flab.matchingtaxi.service.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.matchingtaxi.model.RemoteMessage;
+import com.flab.matchingtaxi.std.RedisStandard;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class RemoteMessageSubscriber implements MessageListener {
+
+    @Autowired
+    private SimpMessageSendingOperations messageSendingOperations;
+    @Autowired
+    private RedisTemplate redisTemplate;
+    @Autowired
+    private RedisService redisService;
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String val = (String)redisTemplate.getStringSerializer().deserialize(message.getBody());
+            RemoteMessage remoteMessage = mapper.readValue(val, RemoteMessage.class);
+            switch (remoteMessage.getContent()){
+                case RedisStandard.RM_COMMAND_DELETE:
+                    boolean result = redisService.deleteTopic(remoteMessage.getTopic());
+                    log.info("on message delete topic : " + result);
+                    break;
+                default:
+                    messageSendingOperations.convertAndSend(RedisStandard.STOMP_DESTINATION_SUB + remoteMessage.getTopic(), remoteMessage);
+                    log.info("on message : " + remoteMessage.toString());
+                    break;
+            }
+        }catch (Exception e){
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/flab/matchingtaxi/std/RedisStandard.java
+++ b/src/main/java/com/flab/matchingtaxi/std/RedisStandard.java
@@ -1,0 +1,11 @@
+package com.flab.matchingtaxi.std;
+
+public class RedisStandard {
+    // hash ops key
+    public static final String HASHOPS_KEY_CHANNEL = "CHANNEL";
+
+    // util
+    public static final String RM_SEPARATER = ":";
+    public static final String RM_COMMAND_DELETE = "DELETE";
+    public static final String RM_EOF = "|";
+}

--- a/src/main/java/com/flab/matchingtaxi/util/RemoteMessageMapper.java
+++ b/src/main/java/com/flab/matchingtaxi/util/RemoteMessageMapper.java
@@ -1,0 +1,22 @@
+package com.flab.matchingtaxi.util;
+
+import com.flab.matchingtaxi.model.RemoteMessage;
+import com.flab.matchingtaxi.std.RedisStandard;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+public class RemoteMessageMapper {
+
+    public static RemoteMessage paramMapping(String sender, String topic, String content){
+        return RemoteMessage.builder()
+                .sender(sender)
+                .topic(topic)
+                .content(content)
+                .build();
+    }
+}


### PR DESCRIPTION
Scale-out상황에 서버 간 서비스 상황(비즈니스 로직, 데이터 등)의 동기화를 위해 서버 간 통신 방식을 구축하였습니다.

실시간 서비스에 적합한 퍼포먼스를 가진 Redis pub/sub 기술을 이용하였습니다.

Redis client connection factory는 비동기 요청처리 기반의 Lettuce를 사용하였습니다.
Message listener container에 connection factory를 연결시켜 빈으로 등록해주었습니다.
Redis ops를 이용하기 위해 template를 빈으로 등록하였고, redis에 저장되는 byte array 형태의 데이터 형식을 서버에서 사용하기 위해 spring-data-redis-serializer를 설정해주었습니다.
